### PR TITLE
Add Buy Sell Buttons to Cards

### DIFF
--- a/pokeapp/src/Brain.js
+++ b/pokeapp/src/Brain.js
@@ -16,8 +16,8 @@ export const Brain = () => {
 
   const [allPokemonFiltered, setAllPokemonFiltered] = useState([]);
   const [selectedPokemon, setSelectedPokemon] = useState({});
-  const [isPokeList, setIsPokeList] = useState(false);
   const [isMoreInfo, setIsMoreInfo] = useState(false);
+  const [isPokeList, setIsPokeList] = useState(false); 
 
   const resolvePokeList = async (pokeList) => {
     return Promise.all(pokeList);
@@ -168,11 +168,10 @@ export const Brain = () => {
               <DigitalCardBinder
                 allPokemonFiltered={allPokemonFiltered}
                 setSelectedPokemon={setSelectedPokemon}
-                isPokeList={isPokeList}
-                setIsPokeList={setIsPokeList}
                 setAllPokemonFiltered={setAllPokemonFiltered}
                 makeUpperCase={makeUpperCase}
                 setIsMoreInfo={setIsMoreInfo}
+                isPokeList={isPokeList}
               />
             }
           />

--- a/pokeapp/src/components/DigitalCardBinder.js
+++ b/pokeapp/src/components/DigitalCardBinder.js
@@ -40,7 +40,6 @@ const DigitalCardBinder = ({
           picture={pokemon.picture}
           types={pokemon.types}
           setSelectedPokemon={setSelectedPokemon}
-          isPokeList={isPokeList}
           makeUpperCase={makeUpperCase}
           setIsMoreInfo={setIsMoreInfo}
         />

--- a/pokeapp/src/components/PokemonCard.js
+++ b/pokeapp/src/components/PokemonCard.js
@@ -6,7 +6,6 @@ import { buyPokemon, sellPokemon } from "../redux/pokemonSlice";
 const PokemonCard = ({
   id,
   setSelectedPokemon,
-  isPokeList,
   makeUpperCase,
   setIsMoreInfo,
 }) => {

--- a/pokeapp/src/components/PokemonCard.js
+++ b/pokeapp/src/components/PokemonCard.js
@@ -46,16 +46,15 @@ const PokemonCard = ({
       <div style={cardImage}></div>
 
       <div className="type-id">
-        {!isPokeList ? (
-          <button
-            onClick={() => {
-              dispatch(buyPokemon(pokemon));
-            }}
-          >
-            Buy
-          </button>
-        ) : null}
-        {!isPokeList && pokemon.quantity > 0 ? (
+        <button
+          onClick={() => {
+            dispatch(buyPokemon(pokemon));
+          }}
+        >
+          Buy
+        </button>
+
+        {pokemon.quantity > 0 ? (
           <button
             onClick={() => {
               dispatch(sellPokemon(pokemon));


### PR DESCRIPTION
## Changes

1. Rendered buy and sell buttons to pokemon cards on myPoke page
2. Item 2

## Purpose
This will allow users to be able to sell pokemon easier on the myPoke page

## Approach
Removed conditional rendering preventing the buttons from being rendered


Closes #64 