### PR TITLE
Stop Unwanted State Updates on Button Click

### DIFF
--- a/pokeapp/src/components/PokemonCard.js
+++ b/pokeapp/src/components/PokemonCard.js
@@ -46,7 +46,8 @@ const PokemonCard = ({
 
       <div className="type-id">
         <button
-          onClick={() => {
+          onClick={(e) => {
+            e.stopPropagation();
             dispatch(buyPokemon(pokemon));
           }}
         >
@@ -55,7 +56,8 @@ const PokemonCard = ({
 
         {pokemon.quantity > 0 ? (
           <button
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
               dispatch(sellPokemon(pokemon));
             }}
           >


### PR DESCRIPTION
## Changes
1. When a user clicks on the buy and sell buttons on a pokemon card, it will not change the sidebar pokemon. 

## Purpose
This will allow the user to buy a pokemon and still have the sidebar pokemon information available

## Approach
Added the stop propagation method to the buy and sell buttons on the pokemon cards

Closes #67 