### PR TITLE
enable scrolling in the won pokemon grid

### DIFF
--- a/pokeapp/src/components/GamePage.js
+++ b/pokeapp/src/components/GamePage.js
@@ -185,11 +185,11 @@ const GamePage = ({makeUpperCase, setIsPokeList}) => {
               </div>
 
             </div>
-            <div className="gamecard-container">
-                <div className="gamepage-card">
-                  {wonPokemon.length ? renderWonPokemons(wonPokemon) : null}
-                </div>
+            
+            <div className="gamepage-card">
+              {wonPokemon.length ? renderWonPokemons(wonPokemon) : null}
             </div>
+
         </div>
     )
 }

--- a/pokeapp/src/styling/components/_gamepage.scss
+++ b/pokeapp/src/styling/components/_gamepage.scss
@@ -12,12 +12,6 @@
     position: relative;
 }
 
-.gamecard-container {
-    grid-area: 3 / 1 / 4 / 3;
-    background-color: $component-container;
-    border-radius: 10px;
-}
-
 // ------------------------------------------------------------------------------------------------SLOT MACHINE PARENT CONTAINER
 
 .slot-machine {
@@ -121,6 +115,21 @@
         transform: translateY(-100%) translateX(-35%);
     }
 }
+
+// ------------------------------------------------------------------------------------------------WON POKEMON GRID
+.gamepage-card {
+    background-color: $component-container;
+    grid-area: 3 / 1 / 4 / 3;
+    border-radius: 10px;
+    color: $font-color;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-auto-rows: 300px;
+    grid-gap: 10px;
+    padding: 10px;
+    overflow: scroll;
+}
+
 
 // ------------------------------------------------------------------------------------------------ANIMATION CONTROLS
 

--- a/pokeapp/src/styling/layout/_game-page-container.scss
+++ b/pokeapp/src/styling/layout/_game-page-container.scss
@@ -10,9 +10,9 @@
     background-color: $base-color;
     grid-gap:0.8em;
     grid-template-columns: 200px 1fr;
-    grid-template-rows: 100px 1fr 0.5fr;
+    grid-template-rows: 100px 500px minmax(300px, 1fr);
     position: fixed;
     padding: 0.8em;
-}
+} 
 
 


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Added the same grid styling from the digital card binder to won pokemon grid


## Purpose
Enables users to scroll through the pokemon they've won 

## Approach
Used the same grid css as the digital card binder



Closes #88 