### PR TITLE
Kf 145 value change

### DIFF
--- a/pokeapp/src/components/badges/utils/allTypesHelper.js
+++ b/pokeapp/src/components/badges/utils/allTypesHelper.js
@@ -80,7 +80,3 @@ export const updateBadgeProgress = (badge, payload, type, count) => {
   }
   return({updatedBadge, count: count+1}); 
 };
-
-export const updateBadgeDegression = () => {
-  
-};

--- a/pokeapp/src/components/badges/utils/allTypesHelper.js
+++ b/pokeapp/src/components/badges/utils/allTypesHelper.js
@@ -80,3 +80,7 @@ export const updateBadgeProgress = (badge, payload, type, count) => {
   }
   return({updatedBadge, count: count+1}); 
 };
+
+export const updateBadgeDegression = () => {
+  
+};

--- a/pokeapp/src/redux/pokemonSlice.js
+++ b/pokeapp/src/redux/pokemonSlice.js
@@ -7,7 +7,7 @@ export const pokemonSlice = createSlice({
   //initialize states
   initialState: {
     allPokemon: [],
-    pokeDollars: 1000,
+    pokeDollars: 10000,
     allBadges: allBadges,
     bugBadgeCount: 0,
     darkBadgeCount: 0,
@@ -36,21 +36,21 @@ export const pokemonSlice = createSlice({
     },
 
     winPokemon: (state, action) => {
-        const pokeIndex = state.allPokemon.findIndex(
-          (element) => element.id === action.payload.id
-        );
-  
-        state.allPokemon[pokeIndex].quantity++;
-        state.pokeDollars = state.pokeDollars - 1000;
+      const pokeIndex = state.allPokemon.findIndex(
+        (element) => element.id === action.payload.id
+      );
+
+      state.allPokemon[pokeIndex].quantity++;
+      state.pokeDollars = state.pokeDollars - 1000;
     },
     buyPokemon: (state, action) => {
-      let type1 = action.payload.types[0].type.name; 
-      let type2 = null; 
+      let type1 = action.payload.types[0].type.name;
+      let type2 = null;
 
-      if(action.payload.types.length > 1){
+      if (action.payload.types.length > 1) {
         type2 = action.payload.types[1].type.name;
       }
- 
+
       if (state.pokeDollars - action.payload.value >= 0) {
         //Finds the index of pokemon in the array that matches the id of the pokemon being updated
         const pokeIndex = state.allPokemon.findIndex(
@@ -602,7 +602,7 @@ export const pokemonSlice = createSlice({
         if (state.allPokemon[pokeIndex].quantity >= 1) {
           state.allPokemon[pokeIndex].quantity--;
           //User gets paid the pokemon's value
-          state.pokeDollars += action.payload.value;
+          state.pokeDollars += Math.floor(action.payload.value * 0.6);
         }
       }
     },


### PR DESCRIPTION
## Changes
1. Lower the resell value of each pokemon
2. Raise the starting amount of pokedollars back to 10000.

## Purpose
Keeps the user from buying and selling pokemon over and over

## Approach
When a pokemon gets sold, only return 60% of it's value to the player


Closes #145 