### PR TITLE
fix the overlapping button on smaller devices

### DIFF
--- a/pokeapp/src/styling/components/_sidebar.scss
+++ b/pokeapp/src/styling/components/_sidebar.scss
@@ -280,6 +280,13 @@
   cursor: pointer;
 }
 
+@media only screen and (max-height: 920px) {
+  .btn-container {
+    position: relative;
+    margin-top: 20px;
+  }
+}
+
 .btn-container-more-info {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Added a height media query to the button container in sidebar

## Purpose
Prevent the buttons from overlapping when screen size becomes smaller

## Approach
SCSS Fix



Closes #179 