### PR TITLE
fix the spacing issue when the percent is at 100

### DIFF
--- a/pokeapp/src/styling/components/_badge-sidebar.scss
+++ b/pokeapp/src/styling/components/_badge-sidebar.scss
@@ -108,6 +108,7 @@
 .progress-container {
   padding-top: 5px;
   padding-left: 9px;
+  padding-right: 10px;
   height: 50%;
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Padding right on the percent container

## Purpose
Prevent the percent container from touching the parent when it is at 100%

## Approach
CSS



Closes #181 